### PR TITLE
fix: correct GitHub Pages deploy so the SPA actually renders

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,8 @@ jobs:
         run: |
           npm ci
           npm run build
+        env:
+          BASE_URL: /drotr/
 
       - name: Deploy to gh-pages
         uses: JamesIves/github-pages-deploy-action@v4
@@ -25,16 +27,15 @@ jobs:
           branch: gh-pages
 
   update-test-coverage-badge:
+    needs: deploy-to-gh-pages
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Install & Build
-        run: |
-          npm ci
-          npm run build
+      - name: Install
+        run: npm ci
 
       - name: Test
         run: npm run test-coverage
@@ -44,8 +45,10 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Deploy to gh-pages
+      - name: Deploy coverage report to gh-pages
         uses: JamesIves/github-pages-deploy-action@v4
         with:
-          folder: dist
+          folder: coverage
           branch: gh-pages
+          target-folder: coverage
+          clean: false

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build --base=https://stevensnoeijen.github.io/drotr/",
+    "build": "vite build",
     "deploy": "gh-pages -d dist",
     "preview": "vite preview",
     "lint": "eslint src",

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -5,7 +5,7 @@ import Game from '~/views/game';
 
 export default function App() {
   return (
-    <BrowserRouter>
+    <BrowserRouter basename={import.meta.env.BASE_URL}>
       <Routes>
         <Route index element={<Home />} />
         <Route path="/game" element={<Game />} />

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,9 @@ import tailwindcss from '@tailwindcss/vite';
 import checker from 'vite-plugin-checker';
 
 export default defineConfig({
+  // Deploy targets (e.g. GitHub Pages) set BASE_URL to the subpath the app
+  // is served from; local dev/build defaults to the site root.
+  base: process.env.BASE_URL ?? '/',
   resolve: {
     alias: {
       '~': path.resolve(__dirname, './src'),
@@ -30,7 +33,7 @@ export default defineConfig({
     },
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'lcov'],
+      reporter: ['text', 'lcov', 'html'],
     },
   },
 });


### PR DESCRIPTION
## Summary
- `https://stevensnoeijen.github.io/drotr/` loaded all assets fine but rendered a blank page with no console errors, because `BrowserRouter` had no `basename` and none of its routes matched under the `/drotr/` subpath GitHub Pages serves from.
- `vite.config.ts` base is now configurable via a `BASE_URL` env var (defaults to `/`), so `npm run build`/`dev`/`preview` are unaffected locally; CI sets `BASE_URL=/drotr/` when building for Pages.
- Fixed a race in `deploy.yml`: `update-test-coverage-badge` was pushing the app's `dist` build to the same `gh-pages` branch in parallel with the real deploy job, so whichever finished last won (sometimes clobbering a correctly-based build with an unbased one). It now runs after the app deploy and publishes the coverage HTML report to `gh-pages:/coverage` instead.
- Added `html` to the Vitest coverage reporters so `coverage/` actually has an `index.html` to publish.

## Test plan
- [x] `npm run build` (local, base `/`) and `BASE_URL=/drotr/ npm run build` (CI) both produce correct asset paths
- [x] Rebuilt `dist`, served it under a simulated `/drotr/` subpath, and confirmed with a headless-browser check that the app now renders (previously blank)
- [x] `npm run build`, `npm run typecheck`, `npm run lint`, `npm test` all pass
- [x] `npm run test-coverage` produces `coverage/index.html`