### PR TITLE
feat: add pan and zoom camera over the tile map

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "lodash": "^4.17.21",
         "miniplex": "^2.0.0",
+        "pixi-viewport": "^6.0.3",
         "pixi.js": "^8.19.0",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
@@ -3557,6 +3558,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pixi-viewport": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/pixi-viewport/-/pixi-viewport-6.0.3.tgz",
+      "integrity": "sha512-2+qPJ0/n+8hQYhWvY+795+x9y3MiUrCOWacK0DY53whowWaGdx9iDocy7z1pBwjkZhC52YvrJQuZKK0sdVLtBw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pixi.js": ">=8"
       }
     },
     "node_modules/pixi.js": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "lodash": "^4.17.21",
     "miniplex": "^2.0.0",
+    "pixi-viewport": "^6.0.3",
     "pixi.js": "^8.19.0",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",

--- a/src/components/game-canvas.spec.tsx
+++ b/src/components/game-canvas.spec.tsx
@@ -15,20 +15,43 @@ const scenario: Scenario = {
 
 interface MockApplication {
   canvas: HTMLCanvasElement;
-  renderer: { resize: ReturnType<typeof vi.fn> };
+  renderer: { resize: ReturnType<typeof vi.fn>; events: object };
   stage: { addChild: ReturnType<typeof vi.fn> };
+  screen: { width: number; height: number };
   ticker: { add: ReturnType<typeof vi.fn>; FPS: number };
   init: ReturnType<typeof vi.fn>;
   destroy: ReturnType<typeof vi.fn>;
 }
 
 let instances: MockApplication[] = [];
+let viewportInstances: MockViewport[] = [];
+
+interface MockViewport {
+  addChild: ReturnType<typeof vi.fn>;
+  addChildAt: ReturnType<typeof vi.fn>;
+  on: ReturnType<typeof vi.fn>;
+  drag: ReturnType<typeof vi.fn>;
+  pinch: ReturnType<typeof vi.fn>;
+  wheel: ReturnType<typeof vi.fn>;
+  clamp: ReturnType<typeof vi.fn>;
+  clampZoom: ReturnType<typeof vi.fn>;
+  resize: ReturnType<typeof vi.fn>;
+  destroy: ReturnType<typeof vi.fn>;
+  worldWidth: number;
+  worldHeight: number;
+  screenWidth: number;
+  screenHeight: number;
+  x: number;
+  y: number;
+  scale: { x: number };
+}
 
 vi.mock('pixi.js', () => {
   class Application implements MockApplication {
     canvas = document.createElement('canvas');
-    renderer = { resize: vi.fn() };
+    renderer = { resize: vi.fn(), events: {} };
     stage = { addChild: vi.fn() };
+    screen = { width: 800, height: 600 };
     ticker = { add: vi.fn(), FPS: 0 };
     init = vi.fn().mockResolvedValue(undefined);
     destroy = vi.fn();
@@ -49,9 +72,38 @@ vi.mock('pixi.js', () => {
   return { Application, Graphics };
 });
 
+vi.mock('pixi-viewport', () => {
+  class Viewport implements MockViewport {
+    addChild = vi.fn();
+    addChildAt = vi.fn();
+    on = vi.fn();
+    drag = vi.fn().mockReturnThis();
+    pinch = vi.fn().mockReturnThis();
+    wheel = vi.fn().mockReturnThis();
+    clamp = vi.fn().mockReturnThis();
+    clampZoom = vi.fn().mockReturnThis();
+    resize = vi.fn();
+    destroy = vi.fn();
+    worldWidth = 800;
+    worldHeight = 600;
+    screenWidth = 800;
+    screenHeight = 600;
+    x = 0;
+    y = 0;
+    scale = { x: 1 };
+
+    constructor() {
+      viewportInstances.push(this);
+    }
+  }
+
+  return { Viewport };
+});
+
 describe('GameCanvas', () => {
   beforeEach(() => {
     instances = [];
+    viewportInstances = [];
   });
 
   let container: HTMLDivElement;
@@ -85,6 +137,11 @@ describe('GameCanvas', () => {
       texture: true,
     });
     expect(container.querySelector('canvas')).toBeNull();
+
+    expect(viewportInstances).toHaveLength(1);
+    expect(viewportInstances[0].destroy).toHaveBeenCalledWith({
+      children: true,
+    });
   });
 
   it('survives StrictMode double-mount with exactly one live Application', async () => {

--- a/src/components/game-canvas.tsx
+++ b/src/components/game-canvas.tsx
@@ -1,12 +1,22 @@
 import { useEffect, useRef } from 'react';
-import { Application, Assets, Graphics, Rectangle, Sprite, Texture } from 'pixi.js';
+import {
+  Application,
+  Assets,
+  type Container,
+  Graphics,
+  Rectangle,
+  Sprite,
+  Texture,
+} from 'pixi.js';
+import type { Viewport } from 'pixi-viewport';
 
 import { spawnUnit } from '~/game/data/spawn';
 import { GameLoop } from '~/game/game-loop';
 import { SystemRunner } from '~/game/ecs/system';
 import { queries, world } from '~/game/ecs/world';
 import type { Renderable } from '~/game/ecs/types';
-import { loadTiledMap, type TerrainType } from '~/game/map/loadTiledMap';
+import { loadTiledMap, type ParsedMap, type TerrainType } from '~/game/map/loadTiledMap';
+import { applyViewportBounds, createGameViewport } from '~/game/render/create-game-viewport';
 import { CELL_SIZE } from '~/lib/grid';
 import {
   serializeDebugFlags,
@@ -35,15 +45,20 @@ const TERRAIN_ATLAS_COLUMN: Record<TerrainType, number> = {
 
 /**
  * Loads a scenario's Tiled map and draws one sprite per tile plus one unit
- * per spawn point, added to `stage` below any existing children.
+ * per spawn point, added to `worldContainer` below any existing children.
+ * Returns the parsed map so the caller can size the camera to its bounds.
  */
 async function drawTiledMap(
   mapSource: string,
-  stage: Application['stage']
-): Promise<void> {
+  worldContainer: Container
+): Promise<ParsedMap> {
   const map = await loadTiledMap(mapSource);
   const atlasUrl = `${import.meta.env.BASE_URL}maps/terrain-atlas.png`;
   const atlas = await Assets.load(atlasUrl);
+  // Nearest-neighbor sampling: the atlas is flat-color placeholder art
+  // packed edge-to-edge, so linear filtering bleeds neighboring tiles'
+  // colors in at non-integer zoom scales, producing visible seams.
+  atlas.source.scaleMode = 'nearest';
 
   const terrainTextures: Record<TerrainType, Texture> = {
     grass: new Texture({
@@ -79,7 +94,7 @@ async function drawTiledMap(
     for (let x = 0; x < map.width; x++) {
       const sprite = new Sprite(terrainTextures[map.terrain[y][x]]);
       sprite.position.set(x * map.tileSize, y * map.tileSize);
-      stage.addChild(sprite);
+      worldContainer.addChild(sprite);
     }
   }
 
@@ -90,6 +105,8 @@ async function drawTiledMap(
       position: spawn.position,
     });
   }
+
+  return map;
 }
 
 /** Draws a light grid overlay over the given canvas size, for `?debug=grid`. */
@@ -104,6 +121,13 @@ function drawGrid(width: number, height: number): Graphics {
   return graphics.stroke({ width: 1, color: 0xffffff, alpha: 0.15 });
 }
 
+/** The camera's current pan/zoom, for consumers doing screen<->grid math. */
+export interface ViewportTransform {
+  x: number;
+  y: number;
+  scale: number;
+}
+
 export interface GameCanvasProps {
   className?: string;
   /** The scenario to seed the world with. */
@@ -115,6 +139,8 @@ export interface GameCanvasProps {
    * read on the caller's side so it can throttle its own re-renders.
    */
   onStats?: (stats: GameStats) => void;
+  /** Called whenever the camera pans or zooms, with its latest transform. */
+  onViewportChange?: (transform: ViewportTransform) => void;
 }
 
 export default function GameCanvas({
@@ -122,9 +148,11 @@ export default function GameCanvas({
   scenario,
   debugFlags,
   onStats,
+  onViewportChange,
 }: GameCanvasProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const onStatsRef = useRef(onStats);
+  const onViewportChangeRef = useRef(onViewportChange);
   const scenarioRef = useRef(scenario);
   const debugFlagsRef = useRef(debugFlags);
   // Set once the Pixi app is ready; re-invoked below whenever debugFlags
@@ -136,6 +164,7 @@ export default function GameCanvas({
   // Pixi-setup effect below (which must run exactly once).
   useEffect(() => {
     onStatsRef.current = onStats;
+    onViewportChangeRef.current = onViewportChange;
     scenarioRef.current = scenario;
     debugFlagsRef.current = debugFlags;
   });
@@ -155,6 +184,7 @@ export default function GameCanvas({
 
     let cancelled = false;
     let app: Application | undefined;
+    let viewport: Viewport | undefined;
     let resizeObserver: ResizeObserver | undefined;
 
     // No systems yet (#78 is the contract only); the runner is empty but the
@@ -169,6 +199,10 @@ export default function GameCanvas({
         background: '#000000',
         antialias: true,
         preference: 'webgl',
+        // Adjacent tile sprites sit edge-to-edge; at the camera's fractional
+        // zoom scales, unrounded sub-pixel positions leave hairline gaps
+        // between them that show the background through as seams.
+        roundPixels: true,
       });
 
       if (cancelled) {
@@ -179,6 +213,28 @@ export default function GameCanvas({
       app = instance;
       container.appendChild(app.canvas);
 
+      const gameViewport = createGameViewport({
+        events: app.renderer.events,
+        screenWidth: app.screen.width,
+        screenHeight: app.screen.height,
+      });
+      viewport = gameViewport;
+      app.stage.addChild(gameViewport);
+      gameViewport.on('moved', () =>
+        onViewportChangeRef.current?.({
+          x: gameViewport.x,
+          y: gameViewport.y,
+          scale: gameViewport.scale.x,
+        })
+      );
+      gameViewport.on('zoomed', () =>
+        onViewportChangeRef.current?.({
+          x: gameViewport.x,
+          y: gameViewport.y,
+          scale: gameViewport.scale.x,
+        })
+      );
+
       // Draw the scenario's map (terrain tiles + map-driven spawns), if it
       // has one, then seed the world from the scenario itself. Positions
       // live in the ECS transform; the unit views below are read-only and
@@ -186,7 +242,12 @@ export default function GameCanvas({
       const { mapSource } = scenarioRef.current;
       if (mapSource) {
         try {
-          await drawTiledMap(mapSource, app.stage);
+          const map = await drawTiledMap(mapSource, gameViewport);
+          applyViewportBounds(
+            gameViewport,
+            map.width * map.tileSize,
+            map.height * map.tileSize
+          );
         } catch (error) {
           console.error(`Failed to load map "${mapSource}":`, error);
         }
@@ -200,19 +261,16 @@ export default function GameCanvas({
       for (const entity of queries.renderable) {
         const view = drawRenderable(entity.renderable);
         views.set(entity, view);
-        app.stage.addChild(view);
+        gameViewport.addChild(view);
       }
 
       let grid: Graphics | undefined;
       const syncGrid = () => {
-        if (!app) {
-          return;
-        }
         grid?.destroy();
         grid = undefined;
         if (debugFlagsRef.current?.has('grid')) {
-          grid = drawGrid(app.screen.width, app.screen.height);
-          app.stage.addChildAt(grid, 0);
+          grid = drawGrid(gameViewport.worldWidth, gameViewport.worldHeight);
+          gameViewport.addChildAt(grid, 0);
         }
       };
       syncGridRef.current = syncGrid;
@@ -240,7 +298,12 @@ export default function GameCanvas({
         const { inlineSize: width, blockSize: height } =
           entry.contentBoxSize[0];
         app?.renderer.resize(width, height);
-        syncGrid();
+        gameViewport.resize(width, height, gameViewport.worldWidth, gameViewport.worldHeight);
+        applyViewportBounds(
+          gameViewport,
+          gameViewport.worldWidth,
+          gameViewport.worldHeight
+        );
       });
       resizeObserver.observe(container);
     })();
@@ -249,6 +312,7 @@ export default function GameCanvas({
       cancelled = true;
       resizeObserver?.disconnect();
       syncGridRef.current = () => {};
+      viewport?.destroy({ children: true });
       if (app) {
         app.canvas.remove();
         app.destroy(true, { children: true, texture: true });

--- a/src/game/render/create-game-viewport.spec.ts
+++ b/src/game/render/create-game-viewport.spec.ts
@@ -1,0 +1,76 @@
+import type { EventSystem } from 'pixi.js';
+import { describe, expect, it } from 'vitest';
+
+import {
+  MAX_ZOOM_SCALE,
+  applyViewportBounds,
+  createGameViewport,
+} from './create-game-viewport';
+
+/** Minimal stand-in for Pixi's EventSystem — enough for the drag/pinch/wheel
+ * plugins to mount without a real renderer. */
+function fakeEvents(): EventSystem {
+  return {
+    domElement: document.createElement('div'),
+    mapPositionToPoint: () => {},
+  } as unknown as EventSystem;
+}
+
+const SCREEN_WIDTH = 800;
+const SCREEN_HEIGHT = 600;
+const WORLD_WIDTH = 2000;
+const WORLD_HEIGHT = 1600;
+
+function buildViewport() {
+  const viewport = createGameViewport({
+    events: fakeEvents(),
+    screenWidth: SCREEN_WIDTH,
+    screenHeight: SCREEN_HEIGHT,
+  });
+  applyViewportBounds(viewport, WORLD_WIDTH, WORLD_HEIGHT);
+  return viewport;
+}
+
+describe('createGameViewport clamping', () => {
+  it('settles panning past the left/top edge at the map origin', () => {
+    const viewport = buildViewport();
+
+    viewport.moveCorner(-500, -500);
+    viewport.plugins.get('clamp')?.update();
+
+    expect(viewport.left).toBe(0);
+    expect(viewport.top).toBe(0);
+  });
+
+  it('settles panning past the right/bottom edge at the map bounds', () => {
+    const viewport = buildViewport();
+
+    viewport.moveCorner(WORLD_WIDTH, WORLD_HEIGHT);
+    viewport.plugins.get('clamp')?.update();
+
+    expect(viewport.right).toBe(WORLD_WIDTH);
+    expect(viewport.bottom).toBe(WORLD_HEIGHT);
+  });
+
+  it('clamps zooming out at the fit-to-screen scale', () => {
+    const viewport = buildViewport();
+    const expectedMinScale = Math.min(
+      SCREEN_WIDTH / WORLD_WIDTH,
+      SCREEN_HEIGHT / WORLD_HEIGHT
+    );
+
+    viewport.setZoom(0.001);
+    viewport.plugins.get('clamp-zoom')?.clamp();
+
+    expect(viewport.scale.x).toBeCloseTo(expectedMinScale);
+  });
+
+  it('clamps zooming in at MAX_ZOOM_SCALE', () => {
+    const viewport = buildViewport();
+
+    viewport.setZoom(1000);
+    viewport.plugins.get('clamp-zoom')?.clamp();
+
+    expect(viewport.scale.x).toBeCloseTo(MAX_ZOOM_SCALE);
+  });
+});

--- a/src/game/render/create-game-viewport.ts
+++ b/src/game/render/create-game-viewport.ts
@@ -1,0 +1,59 @@
+import type { EventSystem } from 'pixi.js';
+import { Viewport } from 'pixi-viewport';
+
+/** Upper bound on how far the camera may zoom in. */
+export const MAX_ZOOM_SCALE = 4;
+
+export interface CreateGameViewportOptions {
+  events: EventSystem;
+  screenWidth: number;
+  screenHeight: number;
+}
+
+/**
+ * Builds the camera that the world (tiles, units, debug overlays) is added
+ * to: drag/pinch/wheel to pan and zoom, clamped once real map bounds are
+ * known via {@link applyViewportBounds}. World size starts equal to screen
+ * size (an effective no-op clamp) until then.
+ */
+export function createGameViewport({
+  events,
+  screenWidth,
+  screenHeight,
+}: CreateGameViewportOptions): Viewport {
+  const viewport = new Viewport({
+    screenWidth,
+    screenHeight,
+    worldWidth: screenWidth,
+    worldHeight: screenHeight,
+    events,
+  });
+
+  viewport.drag().pinch().wheel();
+  applyViewportBounds(viewport, screenWidth, screenHeight);
+
+  return viewport;
+}
+
+/**
+ * Clamps panning to the map's edges and zooming to a range that can't show
+ * empty space beyond them: at minimum the whole map fits on screen, at
+ * maximum it's {@link MAX_ZOOM_SCALE}x.
+ */
+export function applyViewportBounds(
+  viewport: Viewport,
+  worldWidth: number,
+  worldHeight: number
+): void {
+  viewport.worldWidth = worldWidth;
+  viewport.worldHeight = worldHeight;
+
+  const minScale = Math.min(
+    viewport.screenWidth / worldWidth,
+    viewport.screenHeight / worldHeight
+  );
+
+  viewport
+    .clampZoom({ minScale, maxScale: MAX_ZOOM_SCALE })
+    .clamp({ left: 0, top: 0, right: worldWidth, bottom: worldHeight, direction: 'all' });
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
   base: process.env.BASE_URL ?? '/',
   resolve: {
     alias: {
-      '~': path.resolve(__dirname, './src'),
+      '~': path.resolve(import.meta.dirname, './src'),
     },
   },
   plugins: [


### PR DESCRIPTION
## Summary
- Wrap the world (tiles, unit views, debug grid) in a `pixi-viewport` `Viewport` so drag pans, wheel zooms, and pinch zooms on touch devices.
- Clamp panning to the map's edges and zooming to a fit-to-screen minimum / 4x maximum, so the camera can't drift into empty space beyond the map.
- Expose an `onViewportChange` callback with the camera's transform for a future screen→grid conversion (T1.6).
- Fix tile-seam artifacts that showed up under the camera's fractional zoom scales: nearest-neighbor sampling on the terrain atlas (avoids bleeding across packed tile frames) and `roundPixels: true` on the renderer (avoids sub-pixel gaps between adjacent tile sprites).
- Fix a stray Vite config deprecation warning (`__dirname` → `import.meta.dirname`).

Closes #83

## Test plan
- [x] `npm run build`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test` (170 passing, including new clamp/zoom unit tests in `create-game-viewport.spec.ts`)
- [x] Manually verified in a browser: drag pans, wheel zooms, camera settles exactly at map edges and at min/max zoom, no visible tile seams at any zoom level

🤖 Generated with [Claude Code](https://claude.com/claude-code)